### PR TITLE
Adding the Missing Twitch Features Helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muxy/extensions-js",
   "author": "Muxy, Inc.",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "license": "ISC",
   "repository": "https://github.com/muxy/extensions-js",
   "description": "Provides easy access to Muxy's powerful backend architecture for Twitch extensions.",

--- a/src/twitch.ts
+++ b/src/twitch.ts
@@ -51,7 +51,6 @@ export interface TwitchBitsCost {
 }
 
 // Twitch SDK Interfaces
-
 export interface TwitchActionsSDK {
   followChannel(chan: string): void;
   onFollow(cb: (didFollow: boolean, chan: string) => void): void;
@@ -66,6 +65,13 @@ export interface TwitchBitsSDK {
   setUseLoopback: (useLoopback: boolean) => void;
 }
 
+export interface TwitchFeaturesSDK {
+  isBitsEnabled: boolean;
+  isChatEnabled: boolean;
+  isSubscriptionStatusAvailable: boolean;
+  onChanged: (callback: (changes: string[]) => void) => void;
+}
+
 export interface TwitchPurchasesSDK {
   beginPurchase(sku: string): void;
   getPrices(): Promise<any>;
@@ -76,6 +82,7 @@ export interface TwitchPurchasesSDK {
 export interface TwitchSDK {
   actions: TwitchActionsSDK;
   bits: TwitchBitsSDK;
+  features: TwitchFeaturesSDK;
   purchases: TwitchPurchasesSDK;
   settings: any;
 


### PR DESCRIPTION
isBitsEnabled :: If this flag is true, Bits in Extensions features will work in your extension on the current channel

isChatEnabled :: If this flag is true, you can send a chat message to the current channel using Send Extension Chat Message (subject to the authentication requirements documented for that endpoint).

isSubscriptionStatusAvailable :: If this flag is true, your extension has the ability to get the subscription status of identity-linked viewers from both the helper in the window.Twitch.ext.viewer.subscriptionStatus object and via the Twitch API.

onChanged :: This function enables you to receive real-time updates to changes of the features object. If this callback is invoked, you should re-check the window.Twitch.ext.features object for a change to any feature flag your extension cares about. The callback is called with an array of feature flags which were updated.