### PR TITLE
Fix issue with multiple transaction callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muxy/extensions-js",
   "author": "Muxy, Inc.",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "license": "ISC",
   "repository": "https://github.com/muxy/extensions-js",
   "description": "Provides easy access to Muxy's powerful backend architecture for Twitch extensions.",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -404,11 +404,7 @@ export default class SDK {
       mxy.SDKClients[identifier] = this;
     }
 
-    const runningOnTwitch =
-      CurrentEnvironment() === Util.Environments.Production ||
-      CurrentEnvironment() === Util.Environments.SandboxTwitchEnvironment;
-
-    if (mxy.transactionsEnabled && runningOnTwitch) {
+    if (mxy.transactionsEnabled) {
       this.purchaseClient.onUserPurchase((tx: Transaction) => {
         this.client.sendTransactionToServer(this.identifier, tx);
       });


### PR DESCRIPTION
As per the inline comment: Twitch only allows one transaction callback handler at a time. This change allows us to have multiple transactions handlers (e.g. the default that sends to the server for reconciliation and one for updating UI elements).