### PR TITLE
Add support for obtaining a testing helix token

### DIFF
--- a/dist/medkit.umd.js
+++ b/dist/medkit.umd.js
@@ -113,6 +113,16 @@
         return ar;
     }
 
+    function __spreadArray(to, from, pack) {
+        if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+            if (ar || !(i in from)) {
+                if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+                ar[i] = from[i];
+            }
+        }
+        return to.concat(ar || Array.prototype.slice.call(from));
+    }
+
     function unwrapExports (x) {
     	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
     }
@@ -13649,12 +13659,12 @@
         PusherMessenger.prototype.send = function (id, event, target, body, client) {
             var scopedEvent = "".concat(CurrentEnvironment().environment, ":").concat(id, ":").concat(event);
             this.debug.onPubsubSend(id, event, target, body);
-            client.signedRequest(id, 'POST', 'pusher_broadcast', JSON.stringify({
+            client.signedRequest(id, 'POST', 'pusher_broadcast', {
                 data: body,
                 event: scopedEvent,
                 target: target,
                 user_id: this.channelID
-            }));
+            });
         };
         PusherMessenger.prototype.listen = function (id, topic, callback) {
             var _this = this;
@@ -13704,12 +13714,12 @@
         }
         ServerMessenger.prototype.send = function (id, event, target, body, client) {
             this.debug.onPubsubSend(id, event, target, body);
-            client.signedRequest(id, 'POST', 'broadcast', JSON.stringify({
+            client.signedRequest(id, 'POST', 'broadcast', {
                 data: body,
                 event: event,
                 target: target,
                 user_id: this.channelID
-            }));
+            });
         };
         /* tslint:disable:no-console */
         ServerMessenger.prototype.listen = function (id, topic, callback) {
@@ -15014,11 +15024,13 @@
      * @ignore
      */
     var API_URL = 'https://api.muxy.io';
+    var PORTAL_URL = 'https://dev.muxy.io';
     /**
      * Muxy sandbox API URL.
      * @ignore
      */
     var SANDBOX_URL = 'https://sandbox.api.muxy.io';
+    var STAGING_PORTAL_URL = 'https://dev.staging.muxy.io/';
     /**
      * Localhost for testing purposes.
      * @ignore
@@ -15093,17 +15105,20 @@
             if (env === Util.Environments.SandboxDev || env === Util.Environments.SandboxTwitch || env === Util.Environments.SandboxAdmin) {
                 return {
                     FakeAuthURL: SANDBOX_URL,
+                    PortalURL: PORTAL_URL,
                     ServerURL: SANDBOX_URL
                 };
             }
             if (env === Util.Environments.Testing) {
                 return {
                     FakeAuthURL: LOCALHOST_URL,
+                    PortalURL: STAGING_PORTAL_URL,
                     ServerURL: LOCALHOST_URL
                 };
             }
             return {
                 FakeAuthURL: SANDBOX_URL,
+                PortalURL: PORTAL_URL,
                 ServerURL: API_URL
             };
         };
@@ -15178,6 +15193,125 @@
         };
         return DebuggingOptions;
     }());
+
+    var TESTING_HELIX_TOKEN_KEY = "testing_helix_token";
+    function allowTestingHelixToken(id, user) {
+        var _this = this;
+        if (user.helixToken) {
+            return;
+        }
+        var urls = Config$1.GetServerURLs(Util.currentEnvironment());
+        var clientId = id;
+        var useHelixToken = function () { return __awaiter(_this, void 0, void 0, function () {
+            var localToken, sanityToken, req, newToken;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        localToken = localStorage.getItem(TESTING_HELIX_TOKEN_KEY);
+                        if (!localToken) {
+                            return [2 /*return*/, false];
+                        }
+                        try {
+                            sanityToken = JSON.parse(localToken);
+                            if (!sanityToken.access_token || !sanityToken.refresh_token || !sanityToken.expires_in) {
+                                return [2 /*return*/, false];
+                            }
+                        }
+                        catch (e) {
+                            return [2 /*return*/, false];
+                        }
+                        return [4 /*yield*/, fetch("".concat(urls.PortalURL, "/api/tokenauth/").concat(clientId, "/refresh"), {
+                                method: "POST",
+                                body: localToken,
+                            })];
+                    case 1:
+                        req = _a.sent();
+                        return [4 /*yield*/, req.json()];
+                    case 2:
+                        newToken = (_a.sent());
+                        if (newToken.access_token) {
+                            localStorage.setItem(TESTING_HELIX_TOKEN_KEY, JSON.stringify(newToken));
+                            user.helixToken = newToken.access_token;
+                            console.log("Using testing helix token. Call window.ClearHelixToken() to stop this behavior");
+                            return [2 /*return*/, true];
+                        }
+                        else {
+                            console.log("Failed to refresh helix token.");
+                            return [2 /*return*/, false];
+                        }
+                }
+            });
+        }); };
+        var pollForHelixToken = function (rng) { return __awaiter(_this, void 0, void 0, function () {
+            var interval, attempts;
+            var _this = this;
+            return __generator(this, function (_a) {
+                interval = 0;
+                attempts = 0;
+                interval = window.setInterval(function () { return __awaiter(_this, void 0, void 0, function () {
+                    var req, js;
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, fetch("".concat(urls.PortalURL, "/api/tokenauth/").concat(clientId, "/").concat(rng))];
+                            case 1:
+                                req = _a.sent();
+                                return [4 /*yield*/, req.json()];
+                            case 2:
+                                js = (_a.sent());
+                                if (js.access_token) {
+                                    localStorage.setItem("testing_helix_token", JSON.stringify(js));
+                                    clearInterval(interval);
+                                    useHelixToken();
+                                    return [2 /*return*/];
+                                }
+                                attempts++;
+                                if (attempts > 120) {
+                                    console.log("Failed to obtain authentication, try again by calling ObtainHelixToken");
+                                    clearInterval(interval);
+                                    return [2 /*return*/];
+                                }
+                                return [2 /*return*/];
+                        }
+                    });
+                }); }, 2000);
+                return [2 /*return*/];
+            });
+        }); };
+        var obtainHelixToken = function () { return __awaiter(_this, void 0, void 0, function () {
+            var rng;
+            return __generator(this, function (_a) {
+                rng = __spreadArray([], __read(Array(8)), false).map(function () { return Math.random().toString(36)[2]; }).join("");
+                console.log("To obtain a helix token, visit ");
+                console.log("  ".concat(urls.PortalURL, "/login/twitch/token/").concat(clientId, "/").concat(rng));
+                pollForHelixToken(rng);
+                return [2 /*return*/, ""];
+            });
+        }); };
+        var openHelixUrl = function () { return __awaiter(_this, void 0, void 0, function () {
+            var rng;
+            return __generator(this, function (_a) {
+                rng = __spreadArray([], __read(Array(8)), false).map(function () { return Math.random().toString(36)[2]; }).join("");
+                window.open("".concat(urls.PortalURL, "/login/twitch/token/").concat(clientId, "/").concat(rng), "_blank");
+                pollForHelixToken(rng);
+                return [2 /*return*/, ""];
+            });
+        }); };
+        var clearHelixToken = function () {
+            localStorage.removeItem(TESTING_HELIX_TOKEN_KEY);
+            user.helixToken = "";
+        };
+        window.ObtainHelixToken = obtainHelixToken;
+        window.ClearHelixToken = clearHelixToken;
+        var loadHelixToken = useHelixToken();
+        loadHelixToken.then(function (result) {
+            if (!result) {
+                console.log(" To use the debug helix token flow, call window.ObtainHelixToken() in the console");
+            }
+        });
+        return {
+            openHelixUrl: openHelixUrl
+        };
+    }
 
     var UserUpdateCallbackHandle = /** @class */ (function (_super) {
         __extends(UserUpdateCallbackHandle, _super);
@@ -15491,6 +15625,15 @@
          */
         SDK.prototype.loaded = function () {
             return this.loadPromise;
+        };
+        /**
+         * Starts the debug helix token flow. This will throw if
+         * .debug() has not been called.
+         *
+         * @since 2.4.16
+         */
+        SDK.prototype.beginDebugHelixTokenFlow = function () {
+            mxy.beginDebugHelixTokenFlow();
         };
         /**
          * Updates the internally stored user object with the provided value.
@@ -16910,11 +17053,11 @@
          *  console.log(response.users[0].display_name);
          * });
          */
-        TwitchClient.prototype.getTwitchUsersByID = function (userIDs) {
+        TwitchClient.prototype.getTwitchUsersByID = function (userIDs, jwt) {
             if (userIDs.length === 0) {
                 return Promise.resolve([]);
             }
-            return this.signedTwitchHelixRequest('GET', "users?id=".concat(userIDs.join(',')));
+            return this.signedTwitchHelixRequest('GET', "users?id=".concat(userIDs.join(',')), jwt);
         };
         /**
          * Sets the required configuration string enabling an extension to be enabled
@@ -16933,7 +17076,7 @@
     }());
 
     var author = "Muxy, Inc.";
-    var version = "2.4.14";
+    var version = "2.4.16";
     var repository = "https://github.com/muxy/extensions-js";
 
     /**
@@ -16980,6 +17123,12 @@
              * Makes trivia state enum available from the global `Muxy` object
              */
             this.TriviaQuestionState = TriviaQuestionState;
+            /**
+               * Debugging callback, used to start the helix token flow.
+               * @internal
+               * @type {function}
+               */
+            this.openHelixUrl = null;
             this.Util = Util;
             this.setupCalled = false;
             this.testChannelID = '23161357';
@@ -17124,6 +17273,10 @@
                 var resolvePromise = function (user) {
                     var e_2, _a;
                     _this.user = user;
+                    if (_this.debugOptions) {
+                        var openHelixUrl = allowTestingHelixToken(Ext.extensionID, _this.user).openHelixUrl;
+                        _this.openHelixUrl = openHelixUrl;
+                    }
                     var keys = Object.keys(_this.SDKClients);
                     try {
                         for (var keys_2 = __values(keys), keys_2_1 = keys_2.next(); !keys_2_1.done; keys_2_1 = keys_2.next()) {
@@ -17290,6 +17443,20 @@
          */
         Muxy.prototype.debug = function (options) {
             this.debugOptions = __assign(__assign({ channelID: this.testChannelID, role: this.testJWTRole }, this.debugOptions), options.options);
+        };
+        /**
+         * Start the debug helix token flow.
+         */
+        Muxy.prototype.beginDebugHelixTokenFlow = function () {
+            var _this = this;
+            this.loadPromise.then(function () {
+                if (_this.openHelixUrl) {
+                    _this.openHelixUrl();
+                }
+                else {
+                    throw new Error('Muxy.setup() must be called before creating a new TwitchClient instance');
+                }
+            });
         };
         /**
          * Returns a twitch client to use. Can only be used after the loaded promise resolves.

--- a/dist/types/src/config.d.ts
+++ b/dist/types/src/config.d.ts
@@ -3,6 +3,7 @@ import { PurchaseClientType } from './purchase-client';
 import { Environment } from './util';
 export interface ServerURLs {
     ServerURL: string;
+    PortalURL: string;
     FakeAuthURL: string;
 }
 export declare enum AuthorizationFlowType {

--- a/dist/types/src/debug-token.d.ts
+++ b/dist/types/src/debug-token.d.ts
@@ -1,0 +1,10 @@
+import User from "./user";
+declare global {
+    interface Window {
+        ObtainHelixToken: () => void;
+        ClearHelixToken: () => void;
+    }
+}
+export declare function allowTestingHelixToken(id: string, user: User): {
+    openHelixUrl: () => Promise<string>;
+};

--- a/dist/types/src/muxy.d.ts
+++ b/dist/types/src/muxy.d.ts
@@ -288,6 +288,16 @@ export declare class Muxy implements MuxyInterface {
      */
     debug(options: DebuggingOptions): void;
     /**
+       * Debugging callback, used to start the helix token flow.
+       * @internal
+       * @type {function}
+       */
+    private openHelixUrl;
+    /**
+     * Start the debug helix token flow.
+     */
+    beginDebugHelixTokenFlow(): void;
+    /**
      * Returns a twitch client to use. Can only be used after the loaded promise resolves.
      *
      * @since 1.0.0

--- a/dist/types/src/sdk.d.ts
+++ b/dist/types/src/sdk.d.ts
@@ -352,6 +352,13 @@ export default class SDK {
      */
     loaded(): Promise<void>;
     /**
+     * Starts the debug helix token flow. This will throw if
+     * .debug() has not been called.
+     *
+     * @since 2.4.16
+     */
+    beginDebugHelixTokenFlow(): void;
+    /**
      * Updates the internally stored user object with the provided value.
      * Also calls any stored user update callbacks with the new user object.
      * @since 1.5

--- a/dist/types/src/twitch-client.d.ts
+++ b/dist/types/src/twitch-client.d.ts
@@ -169,7 +169,7 @@ export default class TwitchClient {
      *  console.log(response.users[0].display_name);
      * });
      */
-    getTwitchUsersByID(userIDs: string[]): Promise<HelixTwitchUser[]>;
+    getTwitchUsersByID(userIDs: string[], jwt: string): Promise<HelixTwitchUser[]>;
     /**
      * Sets the required configuration string enabling an extension to be enabled
      *

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muxy/extensions-js",
   "author": "Muxy, Inc.",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "license": "ISC",
   "repository": "https://github.com/muxy/extensions-js",
   "description": "Provides easy access to Muxy's powerful backend architecture for Twitch extensions.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,12 +7,14 @@ import Util, { Environment } from './util';
  * @ignore
  */
 const API_URL = 'https://api.muxy.io';
+const PORTAL_URL = 'https://dev.muxy.io';
 
 /**
  * Muxy sandbox API URL.
  * @ignore
  */
 const SANDBOX_URL = 'https://sandbox.api.muxy.io';
+const STAGING_PORTAL_URL = 'https://dev.staging.muxy.io/';
 
 /**
  * Localhost for testing purposes.
@@ -22,6 +24,7 @@ const LOCALHOST_URL = 'http://localhost:5000';
 
 export interface ServerURLs {
   ServerURL: string;
+  PortalURL: string;
   FakeAuthURL: string;
 }
 
@@ -100,6 +103,7 @@ export default class Config {
     if (env === Util.Environments.SandboxDev || env === Util.Environments.SandboxTwitch || env === Util.Environments.SandboxAdmin) {
       return {
         FakeAuthURL: SANDBOX_URL,
+        PortalURL: PORTAL_URL,
         ServerURL: SANDBOX_URL
       };
     }
@@ -107,12 +111,14 @@ export default class Config {
     if (env === Util.Environments.Testing) {
       return {
         FakeAuthURL: LOCALHOST_URL,
+        PortalURL: STAGING_PORTAL_URL,
         ServerURL: LOCALHOST_URL
       };
     }
 
     return {
       FakeAuthURL: SANDBOX_URL,
+      PortalURL: PORTAL_URL,
       ServerURL: API_URL
     };
   }

--- a/src/debug-token.ts
+++ b/src/debug-token.ts
@@ -1,0 +1,123 @@
+import User from "./user";
+import Config from './config';
+import Util from './util';
+
+const TESTING_HELIX_TOKEN_KEY = "testing_helix_token";
+
+interface Token {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+}
+
+declare global {
+  interface Window {
+    ObtainHelixToken: () => void;
+    ClearHelixToken: () => void;
+  }
+}
+
+export function allowTestingHelixToken (id: string, user: User) {
+  if (user.helixToken) {
+    return;
+  }
+
+  const urls = Config.GetServerURLs(Util.currentEnvironment());
+
+  const clientId = id;
+  const useHelixToken = async () => {
+    const localToken = localStorage.getItem(TESTING_HELIX_TOKEN_KEY);
+    if (!localToken) {
+      return false;
+    }
+
+    try {
+      const sanityToken = JSON.parse(localToken) as Token;
+      if (!sanityToken.access_token || !sanityToken.refresh_token || !sanityToken.expires_in) {
+        return false;
+      }
+    } catch (e) {
+      return false;
+    }
+
+    // Immediately refresh the token. Note that localToken is a string.
+    const req = await fetch(`${urls.PortalURL}/api/tokenauth/${clientId}/refresh`, {
+      method: "POST",
+      body: localToken,
+    });
+
+    // Store and use the token.
+    const newToken = (await req.json()) as Token;
+    if (newToken.access_token) {
+      localStorage.setItem(TESTING_HELIX_TOKEN_KEY, JSON.stringify(newToken));
+      user.helixToken = newToken.access_token;
+
+      console.log("Using testing helix token. Call window.ClearHelixToken() to stop this behavior");
+      return true;
+    } else {
+      console.log("Failed to refresh helix token.");
+      return false;
+    }
+  };
+
+  const pollForHelixToken = async (rng: string) => {
+    let interval = 0;
+    let attempts = 0;
+    interval = window.setInterval(async () => {
+      const req = await fetch(`${urls.PortalURL}/api/tokenauth/${clientId}/${rng}`);
+      const js = (await req.json()) as Token;
+
+      if (js.access_token) {
+        localStorage.setItem("testing_helix_token", JSON.stringify(js));
+        clearInterval(interval);
+        useHelixToken();
+        return;
+      }
+
+      attempts++;
+
+      if (attempts > 120) {
+        console.log("Failed to obtain authentication, try again by calling ObtainHelixToken");
+        clearInterval(interval);
+        return;
+      }
+    }, 2000);
+  };
+
+  const obtainHelixToken = async () => {
+    const rng = [...Array(8)].map(() => Math.random().toString(36)[2]).join("");
+
+    console.log("To obtain a helix token, visit ");
+    console.log(`  ${urls.PortalURL}/login/twitch/token/${clientId}/${rng}`);
+
+    pollForHelixToken(rng);
+    return "";
+  };
+
+  const openHelixUrl = async () => {
+    const rng = [...Array(8)].map(() => Math.random().toString(36)[2]).join("");
+    window.open(`${urls.PortalURL}/login/twitch/token/${clientId}/${rng}`, "_blank");
+    pollForHelixToken(rng);
+    return "";
+  };
+
+  const clearHelixToken = () => {
+    localStorage.removeItem(TESTING_HELIX_TOKEN_KEY);
+    user.helixToken = "";
+  };
+
+  window.ObtainHelixToken = obtainHelixToken;
+  window.ClearHelixToken = clearHelixToken;
+
+  const loadHelixToken = useHelixToken();
+
+  loadHelixToken.then((result) => {
+    if (!result) {
+      console.log(" To use the debug helix token flow, call window.ObtainHelixToken() in the console");
+    }
+  });
+
+  return {
+    openHelixUrl
+  };
+}

--- a/src/muxy.ts
+++ b/src/muxy.ts
@@ -5,6 +5,7 @@
 import Analytics from './analytics';
 import Config from './config';
 import { DebuggingOptions, DebugOptions } from './debug';
+import { allowTestingHelixToken } from "./debug-token";
 import DefaultMessenger, { Messenger } from './messenger';
 import DefaultPurchaseClient, { PurchaseClient } from './purchase-client';
 import SDK, { TriviaQuestionState, UserInfo } from './sdk';
@@ -394,6 +395,11 @@ export class Muxy implements MuxyInterface {
       const resolvePromise = (user) => {
         this.user = user;
 
+        if (this.debugOptions) {
+          const { openHelixUrl } = allowTestingHelixToken(Ext.extensionID, this.user);
+          this.openHelixUrl = openHelixUrl;
+        }
+
         const keys = Object.keys(this.SDKClients);
         for (const key of keys) {
           this.SDKClients[key].updateUser(this.user);
@@ -554,6 +560,26 @@ export class Muxy implements MuxyInterface {
       ...this.debugOptions,
       ...options.options
     };
+  }
+
+/**
+   * Debugging callback, used to start the helix token flow.
+   * @internal
+   * @type {function}
+   */
+  private openHelixUrl: () => void = null;
+
+  /**
+   * Start the debug helix token flow.
+   */
+  public beginDebugHelixTokenFlow() {
+    this.loadPromise.then(() => {
+      if (this.openHelixUrl) {
+        this.openHelixUrl();
+      } else {
+        throw new Error('Muxy.setup() must be called before creating a new TwitchClient instance');
+      }
+    });
   }
 
   /**

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -428,6 +428,31 @@ export default class SDK {
   }
 
   /**
+   * Starts the debug helix token flow. This will throw if
+   * .debug() has not been called.
+   *
+   * @since 2.4.16
+   *
+   * @example
+   * const client = new Muxy.TwitchClient();
+   *
+   * // When testing the extension, outside of twitch, the following
+   * // request will not work, since no helixToken is returned from the
+   * // testing auth system.
+   * client.signedTwitchHelixRequest(..., sdk.user.helixToken);
+   *
+   * // Opens a new window to go through the helix token flow.
+   * sdk.beginDebugHelixTokenFlow()
+   *
+   * // After going through the helix flow, then signedTwitchHelixRequest
+   * // call will work
+   * client.signedTwitchHelixRequest(..., sdk.user.helixToken);
+   */
+  public beginDebugHelixTokenFlow() {
+    mxy.beginDebugHelixTokenFlow();
+  }
+
+  /**
    * Updates the internally stored user object with the provided value.
    * Also calls any stored user update callbacks with the new user object.
    * @since 1.5


### PR DESCRIPTION
The testing helix token flow only happens when the debug system
is enabled, and can be accessed through sdk.beginDebugHelixTokenFlow()